### PR TITLE
Made the simulator work

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,22 @@
+import math
+
+# in meters
+kTrackWidth = 0.6096
+
+kWheelRadius = 0.1524 / 2
+kPulsePerRevolution = 360
+kDistancePerPulse = (2 * math.pi * kWheelRadius) / kPulsePerRevolution
+
+# The max velocity and acceleration for our autonomous.
+kMaxSpeedMetersPerSecond = 3
+kMaxAccelerationMetersPerSecondSquared = 0.5
+kMaxVoltage = 10
+
+# sysid filtered results (git 172d5c42, window size=10)
+kS_linear = 1.0898
+kV_linear = 3.1382
+kA_linear = 1.7421
+
+kS_angular = 2.424
+kV_angular = 3.3557
+kA_angular = 1.461

--- a/src/robot.py
+++ b/src/robot.py
@@ -4,6 +4,7 @@
 # must be accompanied by the FIRST BSD license file in the root directory of
 # the project.
 # ----------------------------------------------------------------------------
+from typing import Optional
 
 import rev
 import wpilib
@@ -12,25 +13,45 @@ from wpilib.drive import DifferentialDrive
 
 
 class Robot(wpilib.TimedRobot):
+    def __init__(self):
+        super().__init__()
+        self.is_simulating = False
+
+        self.pdu: Optional[wpilib.PowerDistribution] = None
+
+        self.leftLeadMotor: Optional[rev.CANSparkMax] = None
+        self.rightLeadMotor: Optional[rev.CANSparkMax] = None
+        self.leftFollowMotor: Optional[rev.CANSparkMax] = None
+        self.rightFollowMotor: Optional[rev.CANSparkMax] = None
+
+        self.left: Optional[wpilib.MotorControllerGroup] = None
+        self.right: Optional[wpilib.MotorControllerGroup] = None
+
     def robotInit(self):
+        self.pdu = wpilib.PowerDistribution(50, wpilib.PowerDistribution.ModuleType.kRev)
+
         self.leftLeadMotor = rev.CANSparkMax(10, rev.CANSparkMax.MotorType.kBrushless)
         self.rightLeadMotor = rev.CANSparkMax(40, rev.CANSparkMax.MotorType.kBrushless)
         self.leftFollowMotor = rev.CANSparkMax(20, rev.CANSparkMax.MotorType.kBrushless)
         self.rightFollowMotor = rev.CANSparkMax(30, rev.CANSparkMax.MotorType.kBrushless)
 
+        self.left = wpilib.MotorControllerGroup(self.leftLeadMotor, self.leftFollowMotor)
+        self.right = wpilib.MotorControllerGroup(self.rightLeadMotor, self.rightFollowMotor)
+
         # Passing in the lead motors into DifferentialDrive allows any
         # commmands sent to the lead motors to be sent to the follower motors.
-        self.driveTrain = DifferentialDrive(self.leftLeadMotor, self.rightLeadMotor)
+        self.driveTrain = DifferentialDrive(self.left, self.right)
         self.joystick = wpilib.Joystick(0)
-        
+        self.driveTrain.setExpiration(0.1)
+
         # The RestoreFactoryDefaults method can be used to reset the
         # configuration parameters in the SPARK MAX to their factory default
         # state. If no argument is passed, these parameters will not persist
         # between power cycles
-        self.leftLeadMotor.restoreFactoryDefaults()
-        self.rightLeadMotor.restoreFactoryDefaults()
-        self.leftFollowMotor.restoreFactoryDefaults()
-        self.rightFollowMotor.restoreFactoryDefaults()
+        # self.leftLeadMotor.restoreFactoryDefaults()
+        # self.rightLeadMotor.restoreFactoryDefaults()
+        # self.leftFollowMotor.restoreFactoryDefaults()
+        # self.rightFollowMotor.restoreFactoryDefaults()
 
         # In CAN mode, one SPARK MAX can be configured to follow another. This
         # is done by calling the follow() method on the SPARK MAX you want to
@@ -38,12 +59,26 @@ class Robot(wpilib.TimedRobot):
         # you want to configure as a leader.
         #
         # One motor on each side of our drive train is configured to follow a lead motor.
-        self.leftFollowMotor.follow(self.leftLeadMotor)
-        self.rightFollowMotor.follow(self.rightLeadMotor)
+        # self.leftFollowMotor.follow(self.leftLeadMotor)
+        # self.rightFollowMotor.follow(self.rightLeadMotor)
+    def teleopInit(self):
+        """
+        Configures appropriate robot settings for teleop mode
+        """
+        self.driveTrain.setSafetyEnabled(True)
 
     def teleopPeriodic(self):
         # Drive with arcade style
-        self.driveTrain.arcadeDrive(self.joystick.getX() / 3, self.joystick.getY() / 3)
+        joystick_x = -self.joystick.getX() / 3
+        joystick_y = -self.joystick.getY()
+        self.driveTrain.arcadeDrive(joystick_y, joystick_x)
+
+        if self.is_simulating:  # TODO Figure out if this only works in simulation
+            # TODO Replace 12 with actual bus voltage
+            voltage = self.pdu.getVoltage()
+            self.left.setVoltage(voltage * self.left.get())
+            self.right.setVoltage(voltage * self.right.get())
+
 
 if __name__ == "__main__":
     wpilib.run(Robot)


### PR DESCRIPTION
Worked with Flip to get this to work. Still needs some testing on the actual robot hardware.

What we discovered is that the `set` method in CANSParkMax is setting the internal speed variable and then setting the motor up for kDutyCycle. That did not appear to affect any of the outputs in the simulator. Instead, modifying and setting the voltage motor control group, and therefore the motors themselves, affected the Applied Output of the motor in the simulator, which we could then use to update the drive sim itself.

The two questions I have:
- Should calling set on the CANSParkMax affect any of the simulated variables?
- Is using setVoltage like this something that we should be doing in the simulator or on real hardware? ie is there any harm in this approach.